### PR TITLE
Remove extra text codecheck yml reference

### DIFF
--- a/codecheck.yml
+++ b/codecheck.yml
@@ -9,7 +9,7 @@ paper:
       ORCID: 0000-0001-7972-5634
     - name: Manuel Spitschan
       ORCID: 0000-0002-8572-9268
-  reference: https://osf.io/zrksf/
+  reference: https://doi.org/10.17605/OSF.IO/ZRKSF
 
 manifest:
   - file: 06_output/dem_tab.pdf

--- a/codecheck.yml
+++ b/codecheck.yml
@@ -9,9 +9,7 @@ paper:
       ORCID: 0000-0001-7972-5634
     - name: Manuel Spitschan
       ORCID: 0000-0002-8572-9268
-  reference: >
-    Royal Society Open Science (in press)
-    https://osf.io/zrksf/
+  reference: https://osf.io/zrksf/
 
 manifest:
   - file: 06_output/dem_tab.pdf


### PR DESCRIPTION
In the `codecheck.yml` there was extra text in paper reference. I removed this extra text. 
Refer to comments in another PR about this: [link](https://github.com/codecheckers/register/issues/88#issuecomment-2343273428)

@nuest could you review and merge if you're okay with the changes. I do not have permission to merge.